### PR TITLE
Support Rule ordering in RuleGroup and FirewallPolicy

### DIFF
--- a/aws-networkfirewall-firewall/aws-networkfirewall-firewall.json
+++ b/aws-networkfirewall-firewall/aws-networkfirewall-firewall.json
@@ -45,7 +45,8 @@
       "required": [
         "Value",
         "Key"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "properties": {

--- a/aws-networkfirewall-firewall/pom.xml
+++ b/aws-networkfirewall-firewall/pom.xml
@@ -25,12 +25,18 @@
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.15.33 -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.17.78 -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>networkfirewall</artifactId>
-            <version>2.15.33</version>
-         </dependency>
+            <version>2.17.78</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.17.78</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/aws-networkfirewall-firewallpolicy/.rpdk-config
+++ b/aws-networkfirewall-firewallpolicy/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::NetworkFirewall::FirewallPolicy",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.networkfirewall.firewallpolicy.HandlerWrapperExecutable"
 }

--- a/aws-networkfirewall-firewallpolicy/aws-networkfirewall-firewallpolicy.json
+++ b/aws-networkfirewall-firewallpolicy/aws-networkfirewall-firewallpolicy.json
@@ -75,6 +75,17 @@
           "items": {
             "$ref": "#/definitions/StatefulRuleGroupReference"
           }
+        },
+        "StatefulDefaultActions": {
+          "type": "array",
+          "insertionOrder": false,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "StatefulEngineOptions": {
+          "$ref": "#/definitions/StatefulEngineOptions"
         }
       },
       "required": [
@@ -148,6 +159,9 @@
       "properties": {
         "ResourceArn": {
           "$ref": "#/definitions/ResourceArn"
+        },
+        "Priority": {
+          "$ref": "#/definitions/Priority"
         }
       },
       "required": [
@@ -162,9 +176,7 @@
           "$ref": "#/definitions/ResourceArn"
         },
         "Priority": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535
+          "$ref": "#/definitions/Priority"
         }
       },
       "required": [
@@ -172,6 +184,27 @@
         "Priority"
       ],
       "additionalProperties": false
+    },
+    "Priority": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "StatefulEngineOptions": {
+      "type": "object",
+      "properties": {
+        "RuleOrder": {
+          "$ref": "#/definitions/RuleOrder"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RuleOrder": {
+      "type": "string",
+      "enum": [
+        "DEFAULT_ACTION_ORDER",
+        "STRICT_ORDER"
+      ]
     }
   },
   "properties": {

--- a/aws-networkfirewall-firewallpolicy/aws-networkfirewall-firewallpolicy.json
+++ b/aws-networkfirewall-firewallpolicy/aws-networkfirewall-firewallpolicy.json
@@ -80,7 +80,8 @@
       "required": [
         "StatelessDefaultActions",
         "StatelessFragmentDefaultActions"
-      ]
+      ],
+      "additionalProperties": false
     },
     "CustomAction": {
       "type": "object",
@@ -98,7 +99,8 @@
       "required": [
         "ActionName",
         "ActionDefinition"
-      ]
+      ],
+      "additionalProperties": false
     },
     "ActionDefinition": {
       "type": "object",
@@ -106,7 +108,8 @@
         "PublishMetricAction": {
           "$ref": "#/definitions/PublishMetricAction"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "PublishMetricAction": {
       "type": "object",
@@ -122,7 +125,8 @@
       },
       "required": [
         "Dimensions"
-      ]
+      ],
+      "additionalProperties": false
     },
     "Dimension": {
       "type": "object",
@@ -136,7 +140,8 @@
       },
       "required": [
         "Value"
-      ]
+      ],
+      "additionalProperties": false
     },
     "StatefulRuleGroupReference": {
       "type": "object",
@@ -147,7 +152,8 @@
       },
       "required": [
         "ResourceArn"
-      ]
+      ],
+      "additionalProperties": false
     },
     "StatelessRuleGroupReference": {
       "type": "object",
@@ -164,7 +170,8 @@
       "required": [
         "ResourceArn",
         "Priority"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "properties": {

--- a/aws-networkfirewall-firewallpolicy/pom.xml
+++ b/aws-networkfirewall-firewallpolicy/pom.xml
@@ -25,11 +25,17 @@
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.15.33 -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.17.78 -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>networkfirewall</artifactId>
-            <version>2.15.33</version>
+            <version>2.17.78</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.17.78</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
         <dependency>

--- a/aws-networkfirewall-firewallpolicy/src/main/java/software/amazon/networkfirewall/firewallpolicy/Translator.java
+++ b/aws-networkfirewall-firewallpolicy/src/main/java/software/amazon/networkfirewall/firewallpolicy/Translator.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.networkfirewall.model.ActionDefinition;
 import software.amazon.awssdk.services.networkfirewall.model.Dimension;
 import software.amazon.awssdk.services.networkfirewall.model.PublishMetricAction;
 import software.amazon.awssdk.services.networkfirewall.model.StatefulRuleGroupReference;
+import software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions;
 import software.amazon.awssdk.services.networkfirewall.model.StatelessRuleGroupReference;
 import software.amazon.awssdk.services.networkfirewall.model.UpdateFirewallPolicyRequest;
 
@@ -181,7 +182,26 @@ public class Translator {
             .statelessFragmentDefaultActions(responsePolicy.statelessFragmentDefaultActions().size() != 0
                     ? translateDefaultActionFromSDK(responsePolicy.statelessFragmentDefaultActions()) : null)
             .statelessCustomActions(responsePolicy.statelessCustomActions() != null && responsePolicy.statelessCustomActions().size() != 0 ? translateCustomActionsFromSDK(responsePolicy.statelessCustomActions()): null)
+            .statefulEngineOptions(responsePolicy.statefulEngineOptions() != null ? translateStatefulEngineOptionsFromSDK(responsePolicy.statefulEngineOptions()) : null)
+            .statefulDefaultActions(responsePolicy.statefulDefaultActions() != null && responsePolicy.statefulDefaultActions().size() != 0
+                    ? translateDefaultActionFromSDK(responsePolicy.statefulDefaultActions()) : null)
             .build();
+  }
+
+  private static software.amazon.networkfirewall.firewallpolicy.StatefulEngineOptions translateStatefulEngineOptionsFromSDK(final StatefulEngineOptions statefulEngineOptions) {
+    if (statefulEngineOptions == null) {
+      return null;
+    }
+    return software.amazon.networkfirewall.firewallpolicy.StatefulEngineOptions.builder()
+            .ruleOrder(translateRuleOrderFromSdk(statefulEngineOptions.ruleOrder()))
+            .build();
+  }
+
+  private static String translateRuleOrderFromSdk(final software.amazon.awssdk.services.networkfirewall.model.RuleOrder ruleOrder) {
+    if (ruleOrder == null) {
+      return null;
+    }
+    return ruleOrder.toString();
   }
 
   private static Set<software.amazon.networkfirewall.firewallpolicy.StatefulRuleGroupReference> translateStatefulRuleGroupReferenceFromSDK (
@@ -191,7 +211,9 @@ public class Translator {
     for (StatefulRuleGroupReference reference : references) {
       software.amazon.networkfirewall.firewallpolicy.StatefulRuleGroupReference tempRef =
               software.amazon.networkfirewall.firewallpolicy.StatefulRuleGroupReference.builder()
-                      .resourceArn(reference.resourceArn()).build();
+                      .resourceArn(reference.resourceArn())
+                      .priority(reference.priority())
+                      .build();
       result.add(tempRef);
     }
     return result;
@@ -258,7 +280,12 @@ public class Translator {
                     ? translateDefaultActionToSDK(policy.getStatelessDefaultActions()) : null)
             .statelessFragmentDefaultActions(policy.getStatelessFragmentDefaultActions().size() != 0
                     ? translateDefaultActionToSDK(policy.getStatelessFragmentDefaultActions()) : null)
-            .statelessCustomActions( policy.getStatelessCustomActions() != null && policy.getStatelessCustomActions().size() != 0 ? translateCustomActionsToSDK(policy.getStatelessCustomActions()): null)
+            .statelessCustomActions(policy.getStatelessCustomActions() != null && policy.getStatelessCustomActions().size() != 0
+                    ? translateCustomActionsToSDK(policy.getStatelessCustomActions()): null)
+            .statefulEngineOptions(policy.getStatefulEngineOptions() != null
+                    ? translateStatefulEngineOptionsToSdk(policy.getStatefulEngineOptions()) : null)
+            .statefulDefaultActions(policy.getStatefulDefaultActions() != null && policy.getStatefulDefaultActions().size() != 0
+                    ? translateDefaultActionToSDK(policy.getStatefulDefaultActions()) : null)
             .build();
   }
 
@@ -268,7 +295,9 @@ public class Translator {
 
     for (software.amazon.networkfirewall.firewallpolicy.StatefulRuleGroupReference reference : references) {
       StatefulRuleGroupReference tempRef = StatefulRuleGroupReference.builder()
-                      .resourceArn(reference.getResourceArn()).build();
+                      .resourceArn(reference.getResourceArn())
+                      .priority(reference.getPriority())
+                      .build();
       result.add(tempRef);
     }
     return result;
@@ -322,5 +351,20 @@ public class Translator {
 
   private static List<String> translateDefaultActionToSDK (final Set<String> actions) {
     return new ArrayList<>(actions);
+  }
+
+  private static StatefulEngineOptions translateStatefulEngineOptionsToSdk(
+          final software.amazon.networkfirewall.firewallpolicy.StatefulEngineOptions statefulEngineOptions) {
+    return software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions.builder()
+            .ruleOrder(translateRuleOrderToSdk(statefulEngineOptions.getRuleOrder()))
+            .build();
+  }
+
+  private static software.amazon.awssdk.services.networkfirewall.model.RuleOrder translateRuleOrderToSdk(
+          final String ruleOrder) {
+    if (ruleOrder == null) {
+      return null;
+    }
+    return software.amazon.awssdk.services.networkfirewall.model.RuleOrder.fromValue(ruleOrder);
   }
 }

--- a/aws-networkfirewall-firewallpolicy/src/test/java/software/amazon/networkfirewall/firewallpolicy/AbstractTestBase.java
+++ b/aws-networkfirewall-firewallpolicy/src/test/java/software/amazon/networkfirewall/firewallpolicy/AbstractTestBase.java
@@ -82,12 +82,14 @@ public class AbstractTestBase {
   private static final String dimension = "dimension";
   private static final String statelessAction = "aws:pass";
   private static final String fragmentStatelessAction = "aws:drop";
+  private static final String statefulAction = "aws:drop_strict";
   private static final String description = "Sample description";
   private static final String status = "ACTIVE";
   private static final String deleting = "DELETING";
   private static final String key = "key";
   private static final String key2 = "key2";
   private static final String value = "value";
+  private static final Integer priority = 101;
 
   public final static ResourceModel RESOURCE_MODEL = ResourceModel
           .builder()
@@ -119,6 +121,7 @@ public class AbstractTestBase {
                           .statefulRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatefulRuleGroupReference.builder()
                                           .resourceArn(statefulRuleGroupArn)
+                                          .priority(priority)
                                           .build())
                           .statelessRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatelessRuleGroupReference.builder()
@@ -137,8 +140,11 @@ public class AbstractTestBase {
                                   .build())
                           .statelessDefaultActions(statelessAction,actionName)
                           .statelessFragmentDefaultActions(fragmentStatelessAction)
-                          .build()
-                  )
+                          .statefulEngineOptions(software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions.builder()
+                                  .ruleOrder(RuleOrder.STRICT_ORDER)
+                                  .build())
+                          .statefulDefaultActions(statefulAction)
+                          .build())
                   .tags(TagList())
                   .build();
 
@@ -181,6 +187,7 @@ public class AbstractTestBase {
                           .statefulRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatefulRuleGroupReference.builder()
                                           .resourceArn(statefulRuleGroupArn)
+                                          .priority(priority)
                                           .build())
                           .statelessRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatelessRuleGroupReference.builder()
@@ -199,6 +206,10 @@ public class AbstractTestBase {
                                   .build())
                           .statelessDefaultActions(statelessAction,actionName)
                           .statelessFragmentDefaultActions(fragmentStatelessAction)
+                          .statefulDefaultActions(statefulAction)
+                          .statefulEngineOptions(software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions.builder()
+                                  .ruleOrder(RuleOrder.STRICT_ORDER)
+                                  .build())
                           .build())
                   .build();
 
@@ -221,6 +232,7 @@ public class AbstractTestBase {
                           .statefulRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatefulRuleGroupReference.builder()
                                           .resourceArn(statefulRuleGroupArn)
+                                          .priority(priority)
                                           .build())
                           .statelessRuleGroupReferences(
                                   software.amazon.awssdk.services.networkfirewall.model.StatelessRuleGroupReference.builder()
@@ -239,6 +251,10 @@ public class AbstractTestBase {
                                   .build())
                           .statelessDefaultActions(statelessAction,actionName)
                           .statelessFragmentDefaultActions(fragmentStatelessAction)
+                          .statefulEngineOptions(software.amazon.awssdk.services.networkfirewall.model.StatefulEngineOptions.builder()
+                                  .ruleOrder(RuleOrder.STRICT_ORDER)
+                                  .build())
+                          .statefulDefaultActions(statefulAction)
                           .build()
                   )
                   .build();
@@ -305,12 +321,14 @@ public class AbstractTestBase {
     Set<Dimension> dimensionSet = new HashSet<>();
     Set<String> statelessDefaultAction = new HashSet<>();
     Set<String> fragmentStatelessDefaultAction = new HashSet<>();
+    Set<String> statefulDefaultAction = new HashSet<>();
     statelessReferences.add(StatelessRuleGroupReference.builder()
             .priority(1)
             .resourceArn(statelessRuleGroupArn)
             .build());
     statefulReferences.add(StatefulRuleGroupReference.builder()
             .resourceArn(statefulRuleGroupArn)
+            .priority(101)
             .build());
     dimensionSet.add(Dimension.builder()
             .value(dimension)
@@ -326,6 +344,10 @@ public class AbstractTestBase {
     statelessDefaultAction.add(statelessAction);
     statelessDefaultAction.add(actionName);
     fragmentStatelessDefaultAction.add(fragmentStatelessAction);
+    statefulDefaultAction.add(statefulAction);
+    StatefulEngineOptions statefulEngineOptions = StatefulEngineOptions.builder()
+            .ruleOrder("STRICT_ORDER")
+            .build();
 
     return FirewallPolicy.builder()
             .statefulRuleGroupReferences(statefulReferences)
@@ -333,6 +355,8 @@ public class AbstractTestBase {
             .statelessCustomActions(customAction)
             .statelessDefaultActions(statelessDefaultAction)
             .statelessFragmentDefaultActions(fragmentStatelessDefaultAction)
+            .statefulEngineOptions(statefulEngineOptions)
+            .statefulDefaultActions(statefulDefaultAction)
             .build();
   }
 

--- a/aws-networkfirewall-loggingconfiguration/.rpdk-config
+++ b/aws-networkfirewall-loggingconfiguration/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::NetworkFirewall::LoggingConfiguration",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.networkfirewall.loggingconfiguration.HandlerWrapperExecutable"
 }

--- a/aws-networkfirewall-loggingconfiguration/aws-networkfirewall-loggingconfiguration.json
+++ b/aws-networkfirewall-loggingconfiguration/aws-networkfirewall-loggingconfiguration.json
@@ -25,7 +25,8 @@
       },
       "required": [
         "LogDestinationConfigs"
-      ]
+      ],
+      "additionalProperties": false
     },
     "LogDestinationConfig": {
       "type": "object",
@@ -55,14 +56,16 @@
               "maxLength": 1024
             }
           },
-          "minItems": 1
+          "minItems": 1,
+          "additionalProperties": false
         }
       },
       "required": [
         "LogType",
         "LogDestinationType",
         "LogDestination"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "properties": {

--- a/aws-networkfirewall-loggingconfiguration/pom.xml
+++ b/aws-networkfirewall-loggingconfiguration/pom.xml
@@ -190,7 +190,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.8</minimum>
+                                            <minimum>0.7</minimum>
                                         </limit>
                                         <limit>
                                             <counter>INSTRUCTION</counter>

--- a/aws-networkfirewall-loggingconfiguration/pom.xml
+++ b/aws-networkfirewall-loggingconfiguration/pom.xml
@@ -25,11 +25,17 @@
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.15.33 -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.17.78 -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>networkfirewall</artifactId>
-            <version>2.15.33</version>
+            <version>2.17.78</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.17.78</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
         <dependency>

--- a/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/CreateHandler.java
+++ b/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/CreateHandler.java
@@ -42,10 +42,12 @@ public class CreateHandler extends BaseHandlerStd {
 
         try {
             convertTemplateToUpdateLoggingConfigurationCall(model, proxyClient, false, true);
+
+            Utils.stablize(proxyClient, model);
             return new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger);
         } catch(InvalidRequestException e){
             throw new CfnInvalidRequestException(e);
-        } catch (InternalServerErrorException | LogDestinationPermissionException | ResourceNotFoundException e) {
+        } catch (InternalServerErrorException | LogDestinationPermissionException | ResourceNotFoundException | InterruptedException e) {
             throw new CfnServiceInternalErrorException(ResourceModel.TYPE_NAME, e);
         } catch (ThrottlingException e) {
             throw new CfnThrottlingException(ResourceModel.TYPE_NAME, e);

--- a/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/DeleteHandler.java
+++ b/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/DeleteHandler.java
@@ -36,10 +36,12 @@ public class DeleteHandler extends BaseHandlerStd {
 
         try {
             convertTemplateToUpdateLoggingConfigurationCall(model, proxyClient, true, false);
+
+            Utils.stablize(proxyClient, model);
             return ProgressEvent.defaultSuccessHandler(null);
         } catch(InvalidRequestException e){
             throw new CfnInvalidRequestException(e);
-        } catch (InternalServerErrorException | LogDestinationPermissionException e) {
+        } catch (InternalServerErrorException | LogDestinationPermissionException | InterruptedException e) {
             throw new CfnServiceInternalErrorException(ResourceModel.TYPE_NAME, e);
         } catch (ResourceNotFoundException e) {
             throw new CfnNotFoundException(ResourceModel.TYPE_NAME, e.toString());

--- a/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/UpdateHandler.java
+++ b/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/UpdateHandler.java
@@ -40,10 +40,12 @@ public class UpdateHandler extends BaseHandlerStd {
 
         try {
             convertTemplateToUpdateLoggingConfigurationCall(model, proxyClient);
+
+            Utils.stablize(proxyClient, model);
             return new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger);
         } catch(InvalidRequestException e){
             throw new CfnInvalidRequestException(e);
-        } catch (InternalServerErrorException | LogDestinationPermissionException | ResourceNotFoundException e) {
+        } catch (InternalServerErrorException | LogDestinationPermissionException | ResourceNotFoundException | InterruptedException e) {
             throw new CfnServiceInternalErrorException(ResourceModel.TYPE_NAME, e);
         } catch (ThrottlingException e) {
             throw new CfnThrottlingException(ResourceModel.TYPE_NAME, e);

--- a/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/Utils.java
+++ b/aws-networkfirewall-loggingconfiguration/src/main/java/software/amazon/networkfirewall/loggingconfiguration/Utils.java
@@ -232,8 +232,8 @@ public class Utils {
                 return;
             }
             time++;
-            Thread.sleep(Duration.ofSeconds(2).toMillis());
-        } while (time < 5);
+            Thread.sleep(Duration.ofSeconds(5).toMillis());
+        } while (time < 120);
         throw new CfnNotStabilizedException(ResourceModel.TYPE_NAME, model.getFirewallArn());
     }
 
@@ -244,7 +244,10 @@ public class Utils {
             describeLoggingConfigurationResponse = client.injectCredentialsAndInvokeV2(
                     describeLoggingConfigurationRequest, client.client()::describeLoggingConfiguration);
 
-            return (model.getLoggingConfiguration() == null && describeLoggingConfigurationResponse.loggingConfiguration() == null)
+            return (model.getLoggingConfiguration() == null &&
+                    (describeLoggingConfigurationResponse.loggingConfiguration() == null ||
+                            CollectionUtils.isNullOrEmpty(
+                                    describeLoggingConfigurationResponse.loggingConfiguration().logDestinationConfigs())))
                     || describeLoggingConfigurationResponse.loggingConfiguration()
                     .equals(Translator.toSdkLoggingConfiguration(model.getLoggingConfiguration()));
         } catch (final Exception e) {

--- a/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/CreateHandlerTest.java
+++ b/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/CreateHandlerTest.java
@@ -100,7 +100,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(3)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -146,7 +145,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(3)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -170,7 +168,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThrows(CfnAlreadyExistsException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(0)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -196,7 +193,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThrows(CfnNotFoundException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -219,7 +215,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(0)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -238,6 +233,5 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(0)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 }

--- a/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/DeleteHandlerTest.java
+++ b/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/DeleteHandlerTest.java
@@ -100,7 +100,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(2)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -131,7 +130,8 @@ public class DeleteHandlerTest extends AbstractTestBase {
 
         when(proxyClient.client().describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class)))
                 .thenReturn(preCheckLoggingConfigurationResponse)
-                .thenReturn(preCheckLoggingConfigurationResponse);
+                .thenReturn(preCheckLoggingConfigurationResponse)
+                .thenReturn(finalLoggingConfigurationResponse);
 
         when(proxyClient.client().updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class)))
                 .thenReturn(updateLoggingConfigurationResponse1)
@@ -152,7 +152,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(2)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test

--- a/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/UpdateHandlerTest.java
+++ b/aws-networkfirewall-loggingconfiguration/src/test/java/software/amazon/networkfirewall/loggingconfiguration/UpdateHandlerTest.java
@@ -112,7 +112,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -176,7 +175,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(3)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -241,7 +239,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(3)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -313,7 +310,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(4)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -371,7 +367,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -436,7 +431,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -501,7 +495,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client(), times(2)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(4)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -549,7 +542,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThrows(CfnNotFoundException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(1)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(2)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 
     @Test
@@ -591,6 +583,5 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client(), times(0)).updateLoggingConfiguration(any(UpdateLoggingConfigurationRequest.class));
-        verify(proxyClient.client(), times(1)).describeLoggingConfiguration(any(DescribeLoggingConfigurationRequest.class));
     }
 }

--- a/aws-networkfirewall-rulegroup/aws-networkfirewall-rulegroup.json
+++ b/aws-networkfirewall-rulegroup/aws-networkfirewall-rulegroup.json
@@ -46,6 +46,9 @@
         },
         "RulesSource": {
           "$ref": "#/definitions/RulesSource"
+        },
+        "StatefulRuleOptions": {
+          "$ref": "#/definitions/StatefulRuleOptions"
         }
       },
       "required": [
@@ -559,6 +562,22 @@
         "Value"
       ],
       "additionalProperties": false
+    },
+    "StatefulRuleOptions": {
+      "type": "object",
+      "properties": {
+        "RuleOrder": {
+          "$ref": "#/definitions/RuleOrder"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RuleOrder": {
+      "type": "string",
+      "enum": [
+        "DEFAULT_ACTION_ORDER",
+        "STRICT_ORDER"
+      ]
     }
   },
   "properties": {

--- a/aws-networkfirewall-rulegroup/aws-networkfirewall-rulegroup.json
+++ b/aws-networkfirewall-rulegroup/aws-networkfirewall-rulegroup.json
@@ -50,7 +50,8 @@
       },
       "required": [
         "RulesSource"
-      ]
+      ],
+      "additionalProperties": false
     },
     "RuleVariables": {
       "type": "object",
@@ -61,7 +62,8 @@
             "^[A-Za-z0-9_]{1,32}$": {
               "$ref": "#/definitions/IPSet"
             }
-          }
+          },
+          "additionalProperties": false
         },
         "PortSets": {
           "type": "object",
@@ -69,9 +71,11 @@
             "^[A-Za-z0-9_]{1,32}$": {
               "$ref": "#/definitions/PortSet"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "IPSet": {
       "type": "object",
@@ -84,7 +88,8 @@
             "$ref": "#/definitions/VariableDefinition"
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "PortSet": {
       "type": "object",
@@ -97,7 +102,8 @@
             "$ref": "#/definitions/VariableDefinition"
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "VariableDefinition": {
       "type": "string",
@@ -124,7 +130,8 @@
         "StatelessRulesAndCustomActions": {
           "$ref": "#/definitions/StatelessRulesAndCustomActions"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "RulesSourceList": {
       "type": "object",
@@ -153,7 +160,8 @@
         "Targets",
         "TargetTypes",
         "GeneratedRulesType"
-      ]
+      ],
+      "additionalProperties": false
     },
     "TargetType": {
       "type": "string",
@@ -196,7 +204,8 @@
         "Action",
         "Header",
         "RuleOptions"
-      ]
+      ],
+      "additionalProperties": false
     },
     "Header": {
       "type": "object",
@@ -258,7 +267,8 @@
         "Direction",
         "Destination",
         "DestinationPort"
-      ]
+      ],
+      "additionalProperties": false
     },
     "RuleOption": {
       "type": "object",
@@ -280,7 +290,8 @@
       },
       "required": [
         "Keyword"
-      ]
+      ],
+      "additionalProperties": false
     },
     "Setting": {
       "type": "string",
@@ -316,7 +327,8 @@
       },
       "required": [
         "StatelessRules"
-      ]
+      ],
+      "additionalProperties": false
     },
     "StatelessRule": {
       "type": "object",
@@ -353,7 +365,8 @@
       "required": [
         "MatchAttributes",
         "Actions"
-      ]
+      ],
+      "additionalProperties": false
     },
     "MatchAttributes": {
       "type": "object",
@@ -406,7 +419,8 @@
             "$ref": "#/definitions/TCPFlagField"
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Address": {
       "type": "object",
@@ -420,7 +434,8 @@
       },
       "required": [
         "AddressDefinition"
-      ]
+      ],
+      "additionalProperties": false
     },
     "PortRange": {
       "type": "object",
@@ -435,7 +450,8 @@
       "required": [
         "FromPort",
         "ToPort"
-      ]
+      ],
+      "additionalProperties": false
     },
     "PortRangeBound": {
       "type": "integer",
@@ -469,7 +485,8 @@
       },
       "required": [
         "Flags"
-      ]
+      ],
+      "additionalProperties": false
     },
     "TCPFlag": {
       "type": "string",
@@ -500,7 +517,8 @@
       "required": [
         "ActionName",
         "ActionDefinition"
-      ]
+      ],
+      "additionalProperties": false
     },
     "ActionDefinition": {
       "type": "object",
@@ -524,7 +542,8 @@
       },
       "required": [
         "Dimensions"
-      ]
+      ],
+      "additionalProperties": false
     },
     "Dimension": {
       "type": "object",
@@ -538,7 +557,8 @@
       },
       "required": [
         "Value"
-      ]
+      ],
+      "additionalProperties": false
     }
   },
   "properties": {

--- a/aws-networkfirewall-rulegroup/pom.xml
+++ b/aws-networkfirewall-rulegroup/pom.xml
@@ -25,11 +25,17 @@
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.15.33 -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/networkfirewall/2.17.78 -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>networkfirewall</artifactId>
-            <version>2.15.33</version>
+            <version>2.17.78</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
+            <version>2.17.78</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-collections4 -->
         <dependency>

--- a/aws-networkfirewall-rulegroup/src/main/java/software/amazon/networkfirewall/rulegroup/TagUtils.java
+++ b/aws-networkfirewall-rulegroup/src/main/java/software/amazon/networkfirewall/rulegroup/TagUtils.java
@@ -25,7 +25,7 @@ public class TagUtils {
         this.tagsDiff = computeTagsDiff();
     }
 
-    // tags to add contains both new tags and exiting tag with new value
+    // tags to add contains both new tags and existing tag with new value
     public Map<String, String> tagsToAddOrUpdate() {
         Map<String, String> tagsToAdd = new HashMap<>(tagsDiff.entriesOnlyOnRight());
         // get the tags for those value has changed

--- a/aws-networkfirewall-rulegroup/src/main/java/software/amazon/networkfirewall/rulegroup/Translator.java
+++ b/aws-networkfirewall-rulegroup/src/main/java/software/amazon/networkfirewall/rulegroup/Translator.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.networkfirewall.model.DescribeRuleGroupRe
 import software.amazon.awssdk.services.networkfirewall.model.ListRuleGroupsRequest;
 import software.amazon.awssdk.services.networkfirewall.model.ListRuleGroupsResponse;
 import software.amazon.awssdk.services.networkfirewall.model.RuleGroupResponse;
+import software.amazon.awssdk.services.networkfirewall.model.RuleOrder;
 import software.amazon.awssdk.services.networkfirewall.model.TagResourceRequest;
 import software.amazon.awssdk.services.networkfirewall.model.UntagResourceRequest;
 import software.amazon.awssdk.services.networkfirewall.model.UpdateRuleGroupRequest;
@@ -173,7 +174,25 @@ public class Translator {
         return software.amazon.awssdk.services.networkfirewall.model.RuleGroup.builder()
                 .rulesSource(translateRuleSourceToSdk(ruleGroup.getRulesSource()))
                 .ruleVariables(translateRuleVariablesToSdk(ruleGroup.getRuleVariables()))
+                .statefulRuleOptions(translateStatefulRuleOptionsToSdk(ruleGroup.getStatefulRuleOptions()))
                 .build();
+    }
+
+    static software.amazon.awssdk.services.networkfirewall.model.StatefulRuleOptions translateStatefulRuleOptionsToSdk(
+            final StatefulRuleOptions statefulRuleOptions) {
+        if (statefulRuleOptions == null) {
+            return null;
+        }
+        return software.amazon.awssdk.services.networkfirewall.model.StatefulRuleOptions.builder()
+                .ruleOrder(translateRuleOrderToSdk(statefulRuleOptions.getRuleOrder()))
+                .build();
+    }
+
+    static software.amazon.awssdk.services.networkfirewall.model.RuleOrder translateRuleOrderToSdk(final String ruleOrder) {
+        if (ruleOrder == null) {
+            return null;
+        }
+        return software.amazon.awssdk.services.networkfirewall.model.RuleOrder.fromValue(ruleOrder);
     }
 
     static software.amazon.awssdk.services.networkfirewall.model.RulesSource translateRuleSourceToSdk(final RulesSource rulesSource) {
@@ -535,7 +554,24 @@ public class Translator {
         return RuleGroup.builder()
                 .rulesSource(translateRuleSourceFromSdk(ruleGroup.rulesSource()))
                 .ruleVariables(translateRuleVariablesFromSdk(ruleGroup.ruleVariables()))
+                .statefulRuleOptions(translateStatefulRuleOptionsFromSdk(ruleGroup.statefulRuleOptions()))
                 .build();
+    }
+
+    static StatefulRuleOptions translateStatefulRuleOptionsFromSdk(final software.amazon.awssdk.services.networkfirewall.model.StatefulRuleOptions statefulRuleOptions) {
+        if (statefulRuleOptions == null) {
+            return null;
+        }
+        return StatefulRuleOptions.builder()
+                .ruleOrder(translateRuleOrderFromSdk(statefulRuleOptions.ruleOrder()))
+                .build();
+    }
+
+    static String translateRuleOrderFromSdk(final software.amazon.awssdk.services.networkfirewall.model.RuleOrder ruleOrder) {
+        if (ruleOrder == null) {
+            return null;
+        }
+        return ruleOrder.toString();
     }
 
     static RulesSource translateRuleSourceFromSdk(final software.amazon.awssdk.services.networkfirewall.model.RulesSource rulesSource) {

--- a/aws-networkfirewall-rulegroup/src/test/java/software/amazon/networkfirewall/rulegroup/AbstractTestBase.java
+++ b/aws-networkfirewall-rulegroup/src/test/java/software/amazon/networkfirewall/rulegroup/AbstractTestBase.java
@@ -19,6 +19,7 @@ import software.amazon.awssdk.services.networkfirewall.model.CreateRuleGroupRequ
 import software.amazon.awssdk.services.networkfirewall.model.CreateRuleGroupResponse;
 import software.amazon.awssdk.services.networkfirewall.model.DescribeRuleGroupRequest;
 import software.amazon.awssdk.services.networkfirewall.model.DescribeRuleGroupResponse;
+import software.amazon.awssdk.services.networkfirewall.model.RuleOrder;
 import software.amazon.awssdk.services.networkfirewall.model.TagResourceRequest;
 import software.amazon.awssdk.services.networkfirewall.model.TargetType;
 import software.amazon.awssdk.services.networkfirewall.model.UntagResourceRequest;
@@ -71,19 +72,20 @@ public class AbstractTestBase {
     protected static final String ACTIVE = "ACTIVE";
     protected static final String DELETING = "DELETING";
     protected static final String STATEFUL_PASS_RULE = "pass tcp 10.20.20.0/24 45400:45500 <> 10.10.10.0/24";
+    protected static final String STRICT_RULE_ORDER = "STRICT_ORDER";
 
     protected RuleGroup cfnStatelessRuleGroup1, cfnStatelessRuleGroup2, cfnStatelessRuleGroup3;
-    protected RuleGroup cfnStatefulRuleGroup1, cfnStatefulRuleGroup2, cfnStatefulRuleGroup3, cfnStatefulRuleGroup4;
+    protected RuleGroup cfnStatefulRuleGroup1, cfnStatefulRuleGroup2, cfnStatefulRuleGroup3, cfnStatefulRuleGroup4, cfnStatefulRuleGroup5;
     protected software.amazon.awssdk.services.networkfirewall.model.RuleGroup statelessSdkRuleGroup1, statelessSdkRuleGroup2, statelessSdkRuleGroup3;
     protected software.amazon.awssdk.services.networkfirewall.model.RuleGroupResponse statelessSdkRuleGroupResponseWithNoTags,
             statelessSdkRuleGroupResponseWithTags;
     protected software.amazon.awssdk.services.networkfirewall.model.RuleGroupResponse statefulSdkRuleGroupResponseWithNoTags,
             statefulSdkRuleGroupResponseWithTags;
-    protected software.amazon.awssdk.services.networkfirewall.model.RuleGroup statefulSdkRuleGroup1, statefulSdkRuleGroup2, statefulSdkRuleGroup3, statefulSdkRuleGroup4;
+    protected software.amazon.awssdk.services.networkfirewall.model.RuleGroup statefulSdkRuleGroup1, statefulSdkRuleGroup2, statefulSdkRuleGroup3, statefulSdkRuleGroup4, statefulSdkRuleGroup5;
     protected CreateRuleGroupRequest createStatelessRuleGroupRequest1, createStatelessRuleGroupRequest2, createStatelessRuleGroupRequest3;
     protected CreateRuleGroupResponse createStatelessRuleGroupResponse1, createStatelessRuleGroupResponse2, createStatelessRuleGroupResponse3;
-    protected CreateRuleGroupRequest createStatefulRuleGroupRequest1, createStatefulRuleGroupRequest2, createStatefulRuleGroupRequest3, createStatefulRuleGroupRequest4;
-    protected CreateRuleGroupResponse createStatefulRuleGroupResponse1, createStatefulRuleGroupResponse2, createStatefulRuleGroupResponse3, createStatefulRuleGroupResponse4;
+    protected CreateRuleGroupRequest createStatefulRuleGroupRequest1, createStatefulRuleGroupRequest2, createStatefulRuleGroupRequest3, createStatefulRuleGroupRequest4, createStatefulRuleGroupRequest5;
+    protected CreateRuleGroupResponse createStatefulRuleGroupResponse1, createStatefulRuleGroupResponse2, createStatefulRuleGroupResponse3, createStatefulRuleGroupResponse4, createStatefulRuleGroupResponse5;
     protected DescribeRuleGroupRequest describeCreateStatelessRuleGroupRequest1, describeCreateStatelessRuleGroupRequest2,
             describeCreateStatelessRuleGroupRequest3, describeStatelessRuleGroupRequestWithArn;
     protected DescribeRuleGroupResponse describeCreateStatelessRuleGroupResponse1, describeCreateStatelessRuleGroupResponse2, describeCreateStatelessRuleGroupResponse3;
@@ -91,9 +93,9 @@ public class AbstractTestBase {
     protected DescribeRuleGroupResponse describeUpdateStatelessRuleGroupResponse1, describeUpdateStatelessRuleGroupResponse2, describeUpdateStatelessRuleGroupResponse3;
     protected Set<Tag> statelessTags, statefulTags;
     protected DescribeRuleGroupRequest describeCreateStatefulRuleGroupRequest1, describeCreateStatefulRuleGroupRequest2, describeCreateStatefulRuleGroupRequest3,
-            describeCreateStatefulRuleGroupRequest4, describeStatefulRuleGroupRequestWithArn;
+            describeCreateStatefulRuleGroupRequest4, describeCreateStatefulRuleGroupRequest5, describeStatefulRuleGroupRequestWithArn;
     protected DescribeRuleGroupResponse describeCreateStatefulRuleGroupResponse1, describeCreateStatefulRuleGroupResponse2,
-            describeCreateStatefulRuleGroupResponse3, describeCreateStatefulRuleGroupResponse4;
+            describeCreateStatefulRuleGroupResponse3, describeCreateStatefulRuleGroupResponse4, describeCreateStatefulRuleGroupResponse5;
     protected UpdateRuleGroupRequest updateStatelessRuleGroupRequest1, updateStatelessRuleGroupRequest2, updateStatelessRuleGroupRequest3;
     protected UpdateRuleGroupResponse updateStatelessRuleGroupResponse1, updateStatelessRuleGroupResponse2, updateStatelessRuleGroupResponse3;
     protected UpdateRuleGroupRequest updateStatefulRuleGroupRequest1, updateStatefulRuleGroupRequest2, updateStatefulRuleGroupRequest3;
@@ -662,11 +664,13 @@ public class AbstractTestBase {
         cfnStatefulRuleGroup2 = createStatefulRuleGroup2();
         cfnStatefulRuleGroup3 = createStatefulRuleGroup3();
         cfnStatefulRuleGroup4 = createStatefulRuleGroup4();
+        cfnStatefulRuleGroup5 = createStatefulRuleGroup5();
 
         statefulSdkRuleGroup1 = translateToStatefulSdkRuleGroup1();
         statefulSdkRuleGroup2 = translateToStatefulSdkRuleGroup2();
         statefulSdkRuleGroup3 = translateToStatefulSdkRuleGroup3();
         statefulSdkRuleGroup4 = translateToStatefulSdkRuleGroup4();
+        statefulSdkRuleGroup5 = translateToStatefulSdkRuleGroup5();
 
         statefulTags = Collections.singleton(Tag.builder()
                 .key("rule-group")
@@ -811,6 +815,33 @@ public class AbstractTestBase {
         describeCreateStatefulRuleGroupResponse4 = DescribeRuleGroupResponse.builder()
                 .ruleGroupResponse(statefulSdkRuleGroupResponseWithTags)
                 .ruleGroup(statefulSdkRuleGroup4)
+                .updateToken(UPDATE_TOKEN)
+                .build();
+
+        // Stateful RuleGroup Request with tags - request5
+        createStatefulRuleGroupRequest5 = CreateRuleGroupRequest.builder()
+                .ruleGroup(statefulSdkRuleGroup5)
+                .capacity(CAPACITY)
+                .description(DESCRIPTION)
+                .type(STATEFUL_RULEGROUP_TYPE)
+                .ruleGroupName(STATEFUL_RULEGROUP_NAME)
+                .tags(sdkStatefulTags)
+                .build();
+
+        createStatefulRuleGroupResponse5 = CreateRuleGroupResponse.builder()
+                .ruleGroupResponse(statefulSdkRuleGroupResponseWithTags)
+                .updateToken(UPDATE_TOKEN)
+                .build();
+
+        describeCreateStatefulRuleGroupRequest5 = DescribeRuleGroupRequest.builder()
+                .ruleGroupName(STATEFUL_RULEGROUP_NAME)
+                .type(STATEFUL_RULEGROUP_TYPE)
+                .ruleGroupArn(STATEFUL_RULEGROUP_ARN)
+                .build();
+
+        describeCreateStatefulRuleGroupResponse5 = DescribeRuleGroupResponse.builder()
+                .ruleGroupResponse(statefulSdkRuleGroupResponseWithTags)
+                .ruleGroup(statefulSdkRuleGroup5)
                 .updateToken(UPDATE_TOKEN)
                 .build();
 
@@ -1007,6 +1038,56 @@ public class AbstractTestBase {
                         .ipSets(ImmutableMap.of("test", software.amazon.awssdk.services.networkfirewall.model.IPSet.builder()
                                 .definition(Collections.singleton("test-definition-1, test-definition-2"))
                                 .build()))
+                        .build())
+                .build();
+    }
+
+    private RuleGroup createStatefulRuleGroup5() {
+        return RuleGroup.builder()
+                .rulesSource(RulesSource.builder()
+                        .statefulRules(Collections.singleton(StatefulRule.builder()
+                                .action("PASS")
+                                .header(Header.builder()
+                                        .sourcePort("any")
+                                        .destinationPort("any")
+                                        .source("$HOME_NET")
+                                        .destination("$EXTERNAL_NET")
+                                        .protocol("TCP")
+                                        .direction("FORWARD")
+                                        .build())
+                                .ruleOptions(Collections.singleton(RuleOption.builder()
+                                        .keyword("sid")
+                                        .settings(Collections.singleton("100"))
+                                        .build()))
+                                .build()))
+                        .build())
+                .statefulRuleOptions(StatefulRuleOptions.builder()
+                        .ruleOrder("STRICT_ORDER")
+                        .build())
+                .build();
+    }
+
+    private software.amazon.awssdk.services.networkfirewall.model.RuleGroup translateToStatefulSdkRuleGroup5() {
+        return software.amazon.awssdk.services.networkfirewall.model.RuleGroup.builder()
+                .rulesSource(software.amazon.awssdk.services.networkfirewall.model.RulesSource.builder()
+                        .statefulRules(Collections.singleton(software.amazon.awssdk.services.networkfirewall.model.StatefulRule.builder()
+                                .action("PASS")
+                                .header(software.amazon.awssdk.services.networkfirewall.model.Header.builder()
+                                        .protocol("TCP")
+                                        .source("$HOME_NET")
+                                        .direction("FORWARD")
+                                        .sourcePort("any")
+                                        .destinationPort("any")
+                                        .destination("$EXTERNAL_NET")
+                                        .build())
+                                .ruleOptions(Collections.singleton(software.amazon.awssdk.services.networkfirewall.model.RuleOption.builder()
+                                        .settings("100")
+                                        .keyword("sid")
+                                        .build()))
+                                .build()))
+                        .build())
+                .statefulRuleOptions(software.amazon.awssdk.services.networkfirewall.model.StatefulRuleOptions.builder()
+                        .ruleOrder(RuleOrder.STRICT_ORDER)
                         .build())
                 .build();
     }

--- a/aws-networkfirewall-rulegroup/src/test/java/software/amazon/networkfirewall/rulegroup/CreateHandlerTest.java
+++ b/aws-networkfirewall-rulegroup/src/test/java/software/amazon/networkfirewall/rulegroup/CreateHandlerTest.java
@@ -388,6 +388,43 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void testHandleRequest_createStatefulRuleGroupSuccess5() {
+        // create request with stateful-rulegroup - with RuleOrder
+        model = ResourceModel
+                .builder()
+                .ruleGroupName(STATEFUL_RULEGROUP_NAME)
+                .ruleGroup(cfnStatefulRuleGroup5)
+                .description(DESCRIPTION)
+                .capacity(CAPACITY)
+                .type(STATEFUL_RULEGROUP_TYPE)
+                .tags(statefulTags)
+                .build();
+        request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        when(proxyClient.injectCredentialsAndInvokeV2(createStatefulRuleGroupRequest5, networkFirewallClient::createRuleGroup)).thenReturn(createStatefulRuleGroupResponse5);
+        when(proxyClient.injectCredentialsAndInvokeV2(describeCreateStatefulRuleGroupRequest5, networkFirewallClient::describeRuleGroup)).thenReturn(describeCreateStatefulRuleGroupResponse5);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        verify(proxyClient.client(), times(1)).createRuleGroup(any(CreateRuleGroupRequest.class));
+        verify(proxyClient.client(), times(2)).describeRuleGroup(any(DescribeRuleGroupRequest.class));
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel().getRuleGroupName()).isEqualTo(request.getDesiredResourceState().getRuleGroupName());
+        assertThat(response.getResourceModel().getType()).isEqualTo(request.getDesiredResourceState().getType());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        // Validate ResourceModel
+        validateStatefulResourceModel(response.getResourceModel(), cfnStatefulRuleGroup5, statefulTags);
+    }
+
+    @Test
     public void testHandleRequest_throwsInvalidRequestException() {
         when(proxyClient.injectCredentialsAndInvokeV2(createStatelessRuleGroupRequest1, networkFirewallClient::createRuleGroup)).thenThrow(InvalidRequestException.class);
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,7 @@ phases:
         python: 3.7
     commands:
       -  pip install pre-commit cloudformation-cli-java-plugin
+      -  pip install --upgrade 'six==1.15.0'
   build:
     commands:
       - pre-commit run --all-files


### PR DESCRIPTION
- RuleGroup:
     - Added StatefulRuleOptions with RuleOrder to the RuleGroup schema
     - Made changes to the translator to support the new Rule ordering
    
 - FirewallPolicy:
     - Added StatefulDefaultActions, Priority to StatefulRuleGroupReferences, StatefulEngineOptions with RuleOrder to the FirewallPolicy schema
     - Made changes to the translator to support the new schema changes